### PR TITLE
Change Twitter to X (Formerly known as Twitter)

### DIFF
--- a/Fluffle.UI/src/pages/index.tsx
+++ b/Fluffle.UI/src/pages/index.tsx
@@ -14,7 +14,7 @@ import { dropZone, dropZoneActive } from './index.module.scss'
 
 import SEO from '../components/seo'
 export const Head = () => (
-    <SEO title="Reverse search" description="Reverse image search furry artwork and find the source on Fur Affinity, X (Formerly know as Twitter), e621 and more!" />
+    <SEO title="Reverse search" description="Reverse image search furry artwork and find the source on Fur Affinity, X (Formerly known as Twitter), e621 and more!" />
 )
 
 const State = {
@@ -300,7 +300,7 @@ const SearchPage = ({ forBrowserExtension, searchResult }) => {
                                             <button onClick={() => searchConfig.setIncludeNsfw(true)} className={`btn btn-${searchConfig.includeNsfw ? "danger" : "secondary"}`} data-ignore>NSFW</button>
                                         </div>
                                     </div>
-                                    <div className="text-sm text-muted">{!searchConfig.includeNsfw ? "X (Formerly know as Twitter) isn't included in SFW mode." : 'Search both SFW and NSFW images.'}</div>
+                                    <div className="text-sm text-muted">{!searchConfig.includeNsfw ? "X (Formerly known as Twitter) isn't included in SFW mode." : 'Search both SFW and NSFW images.'}</div>
                                 </div>
                                 <div className="text-muted">Fluffle also has a Telegram bot and a browser extension, interested? Check out the <Link to="/tools/">tools page</Link>.</div>
                             </div>

--- a/Fluffle.UI/src/pages/index.tsx
+++ b/Fluffle.UI/src/pages/index.tsx
@@ -14,7 +14,7 @@ import { dropZone, dropZoneActive } from './index.module.scss'
 
 import SEO from '../components/seo'
 export const Head = () => (
-    <SEO title="Reverse search" description="Reverse image search furry artwork and find the source on Fur Affinity, Twitter, e621 and more!" />
+    <SEO title="Reverse search" description="Reverse image search furry artwork and find the source on Fur Affinity, X (Formerly know as Twitter), e621 and more!" />
 )
 
 const State = {
@@ -300,7 +300,7 @@ const SearchPage = ({ forBrowserExtension, searchResult }) => {
                                             <button onClick={() => searchConfig.setIncludeNsfw(true)} className={`btn btn-${searchConfig.includeNsfw ? "danger" : "secondary"}`} data-ignore>NSFW</button>
                                         </div>
                                     </div>
-                                    <div className="text-sm text-muted">{!searchConfig.includeNsfw ? "Twitter isn't included in SFW mode." : 'Search both SFW and NSFW images.'}</div>
+                                    <div className="text-sm text-muted">{!searchConfig.includeNsfw ? "X (Formerly know as Twitter) isn't included in SFW mode." : 'Search both SFW and NSFW images.'}</div>
                                 </div>
                                 <div className="text-muted">Fluffle also has a Telegram bot and a browser extension, interested? Check out the <Link to="/tools/">tools page</Link>.</div>
                             </div>


### PR DESCRIPTION
Update the wording to be correct for the current internet.
Since the rebranding to X most people call it X (Formerly known as Twitter) as a joke. And well, it is more correct than just twitter.